### PR TITLE
Add data gathering scripts and prediction model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
-# Times-Person-Of-The-Year-Prediction-Algorithm
+# Times Person Of The Year Prediction Algorithm
+
+This repository contains example scripts that collect public data and train a
+simple machine learning model to estimate who might become TIME's "Person of
+the Year".
+
+## Setup
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+For Twitter data you also need an API token. Set it in the environment as
+`TWITTER_BEARER_TOKEN`.
+
+## Data Collection
+
+1. **Scrape TIME covers**
+   ```bash
+   python scrape_time_covers.py
+   ```
+   This creates `time_covers_2000_2024.csv` containing the date and subject of
+   each magazine cover between 2000 and 2024.
+
+2. **Wikipedia page views**
+   Prepare a CSV called `shortlist_2024.csv` with a column `Name` listing the
+   people you want to track. Then run:
+   ```bash
+   python wikipedia_pageviews.py
+   ```
+   The script stores monthly view counts in `wikipedia_views.csv`.
+
+3. **Twitter mentions**
+   ```bash
+   python twitter_mentions.py
+   ```
+   This uses the Twitter API to fetch monthly counts and saves them to
+   `twitter_mentions.csv`.
+
+## Preparing Training Data
+
+Combine the collected page views and mention counts into a file
+`training_features.csv` with columns:
+`Year,Name,Views,Tweet Count`. Create another file `winners.csv` containing the
+historical winners with columns `Year,Winner` (these can be copied from
+Wikipedia).
+
+For the year you want predictions for, assemble a similar features file (for
+example `features_2024.csv`).
+
+## Training and Prediction
+
+Run the model script:
+
+```bash
+python poty_model.py
+```
+
+The script performs a simple grid search over a RandomForest classifier,
+outputs classification metrics, saves the model to
+`person_of_the_year_model.pkl`, and prints predicted scores for the upcoming
+year based on `features_2024.csv`.
+
+## Disclaimer
+
+These scripts rely only on public metadata (such as Wikipedia view counts and
+Twitter mention totals). They do not redistribute any copyrighted TIME
+content.

--- a/poty_model.py
+++ b/poty_model.py
@@ -1,0 +1,59 @@
+import pandas as pd
+from sklearn.model_selection import train_test_split, GridSearchCV
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import classification_report, accuracy_score
+import joblib
+
+
+def load_training_data(features_csv: str, winners_csv: str):
+    """Merge feature data with winners to build a labelled dataset."""
+    features = pd.read_csv(features_csv)
+    winners = pd.read_csv(winners_csv)
+
+    data = features.merge(winners, on="Year", how="left")
+    data["Label"] = (data["Name"] == data["Winner"]).astype(int)
+    data.fillna(0, inplace=True)
+
+    X = data[["Views", "Tweet Count"]]
+    y = data["Label"]
+    return X, y
+
+
+def train_model(X, y):
+    """Train a RandomForest model with simple grid search."""
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42, stratify=y
+    )
+
+    param_grid = {"n_estimators": [100, 200, 300], "max_depth": [None, 5, 10]}
+    clf = RandomForestClassifier(random_state=42)
+    search = GridSearchCV(clf, param_grid, cv=5, scoring="accuracy")
+    search.fit(X_train, y_train)
+
+    best = search.best_estimator_
+    y_pred = best.predict(X_test)
+    print("Best parameters:", search.best_params_)
+    print(classification_report(y_test, y_pred))
+    print("Accuracy:", accuracy_score(y_test, y_pred))
+
+    joblib.dump(best, "person_of_the_year_model.pkl")
+    return best
+
+
+def predict_next_year(model_path: str, features_csv: str):
+    model = joblib.load(model_path)
+    df = pd.read_csv(features_csv)
+    X_future = df[["Views", "Tweet Count"]]
+    df["Score"] = model.predict_proba(X_future)[:, 1]
+    return df.sort_values("Score", ascending=False)
+
+
+if __name__ == "__main__":
+    # paths can be changed as needed
+    X, y = load_training_data("training_features.csv", "winners.csv")
+    trained_model = train_model(X, y)
+
+    predictions = predict_next_year(
+        "person_of_the_year_model.pkl", "features_2024.csv"
+    )
+    print(predictions[["Name", "Score"]].head())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+beautifulsoup4
+requests
+pandas
+scikit-learn
+joblib

--- a/scrape_time_covers.py
+++ b/scrape_time_covers.py
@@ -1,0 +1,37 @@
+import requests
+from bs4 import BeautifulSoup
+import csv
+import time
+
+
+def scrape_time_covers(start_year=2000, end_year=2024):
+    """Scrape TIME magazine cover subjects and dates from the vault."""
+    base_url = "https://time.com/vault/year/"
+    all_data = []
+
+    for year in range(start_year, end_year + 1):
+        url = f"{base_url}{year}"
+        print(f"Scraping {url}")
+        res = requests.get(url)
+        soup = BeautifulSoup(res.text, 'html.parser')
+
+        issues = soup.find_all("div", class_="partial cover-item")
+
+        for issue in issues:
+            date = issue.find("span", class_="vault-cover-date").text.strip()
+            cover_subject = issue.find("h3", class_="headline")
+            subject = cover_subject.text.strip() if cover_subject else "Unknown"
+            all_data.append([year, date, subject])
+
+        time.sleep(1)  # be nice to their servers
+
+    with open("time_covers_2000_2024.csv", "w", newline='', encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["Year", "Issue Date", "Cover Subject"])
+        writer.writerows(all_data)
+
+    print("✅ Finished scraping TIME covers.")
+
+
+if __name__ == "__main__":
+    scrape_time_covers()

--- a/twitter_mentions.py
+++ b/twitter_mentions.py
@@ -1,0 +1,48 @@
+import requests
+import csv
+import os
+
+BEARER_TOKEN = os.getenv("TWITTER_BEARER_TOKEN")
+
+
+def create_headers():
+    return {"Authorization": f"Bearer {BEARER_TOKEN}"}
+
+
+def get_mention_count(query, start_time="2024-01-01T00:00:00Z", end_time="2024-12-31T00:00:00Z"):
+    url = "https://api.twitter.com/2/tweets/counts/all"
+    params = {
+        "query": query,
+        "start_time": start_time,
+        "end_time": end_time,
+        "granularity": "month",
+    }
+    headers = create_headers()
+    response = requests.get(url, headers=headers, params=params)
+
+    if response.status_code != 200:
+        print(f"Error for {query}: {response.text}")
+        return []
+
+    data = response.json()
+    return [(query, item["start"], item["tweet_count"]) for item in data.get("data", [])]
+
+
+def save_mentions(data, filename="twitter_mentions.csv"):
+    with open(filename, "w", newline='', encoding='utf-8') as f:
+        writer = csv.writer(f)
+        writer.writerow(["Name", "Month", "Tweet Count"])
+        writer.writerows(data)
+
+
+if __name__ == "__main__":
+    names = ["Taylor Swift", "Elon Musk", "Donald Trump"]  # example
+    all_data = []
+
+    for name in names:
+        query = f'"{name}" lang:en'
+        results = get_mention_count(query)
+        all_data.extend(results)
+
+    save_mentions(all_data)
+    print("✅ Twitter mentions saved.")

--- a/wikipedia_pageviews.py
+++ b/wikipedia_pageviews.py
@@ -1,0 +1,43 @@
+import requests
+import csv
+
+
+def get_pageviews(title, start="20240101", end="20241231"):
+    """Fetch monthly Wikipedia pageviews for a title."""
+    url = (
+        "https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/"
+        f"en.wikipedia/all-access/all-agents/{title}/monthly/{start}/{end}"
+    )
+    r = requests.get(url)
+    if r.status_code != 200:
+        return []
+
+    data = r.json().get("items", [])
+    return [(title, item["timestamp"], item["views"]) for item in data]
+
+
+def load_titles_from_csv(filename):
+    with open(filename, newline='', encoding='utf-8') as f:
+        reader = csv.reader(f)
+        return [row[0] for row in list(reader)[1:]]
+
+
+def save_to_csv(data, filename="wikipedia_views.csv"):
+    with open(filename, "w", newline='', encoding='utf-8') as f:
+        writer = csv.writer(f)
+        writer.writerow(["Title", "Date", "Views"])
+        writer.writerows(data)
+
+
+if __name__ == "__main__":
+    titles = load_titles_from_csv("shortlist_2024.csv")  # file with column 'Name'
+    all_views = []
+
+    for name in titles:
+        title = name.replace(" ", "_")
+        print(f"Fetching views for: {title}")
+        views = get_pageviews(title)
+        all_views.extend(views)
+
+    save_to_csv(all_views)
+    print("✅ Wikipedia views saved.")


### PR DESCRIPTION
## Summary
- add scripts for scraping TIME covers, wiki pageviews, and twitter mentions
- implement `poty_model.py` with RandomForest and grid search
- document workflow in README
- include requirements file

## Testing
- `python -m py_compile scrape_time_covers.py wikipedia_pageviews.py twitter_mentions.py poty_model.py`

------
https://chatgpt.com/codex/tasks/task_e_686a12cd21c0832ead2cdf46588958dc